### PR TITLE
Replacing GenericForeignKey from generic to fields

### DIFF
--- a/calendarium/models.py
+++ b/calendarium/models.py
@@ -11,7 +11,7 @@ import json
 from dateutil import rrule
 
 from django.conf import settings
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.core.validators import RegexValidator
@@ -356,7 +356,7 @@ class EventRelation(models.Model):
 
     object_id = models.IntegerField()
 
-    content_object = generic.GenericForeignKey(
+    content_object = GenericForeignKey(
         'content_type',
         'object_id',
     )


### PR DESCRIPTION
`django.contrib.contenttypes import generic` were deprecated in django 1.9 as can be seen [here](https://docs.djangoproject.com/en/1.9/releases/1.9/).

